### PR TITLE
Temp hack for GO for 6.0 artifact changes

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -41,6 +41,7 @@ impl Default for SavedAppState {
                 include_artifacts: true,
                 include_weapons: true,
                 include_materials: true,
+                fake_initialize_4th_line: false,
                 min_character_level: 1,
                 min_character_ascension: 0,
                 min_character_constellation: 0,
@@ -823,6 +824,12 @@ impl IrminsulApp {
         ui.checkbox(
             &mut self.saved_state.export_settings.include_materials,
             "Materials",
+        );
+        ui.checkbox(
+            &mut self.saved_state.export_settings.fake_initialize_4th_line,
+            "Fake level-up 5* artifacts with unactivated stats (hover for more info)"
+        ).on_hover_text(
+            "Genshin Optimizer still internally treats 5* 3-liners like pre-6.0, where the new stat is \"hidden\" and unknown to GO's optimizer.\nThis is a temporary workaround by activating that last stat line, but to prevent unintended effects, the artifacts are set to level 4, mimicking the player leveling it up.\nThe last line *should* be the unlockable 4th line."
         );
         ui.separator();
         egui::Sides::new().show(

--- a/src/good.rs
+++ b/src/good.rs
@@ -85,3 +85,20 @@ pub fn to_good_key(value: &str) -> String {
 
     result
 }
+
+pub fn fake_uninitialized_4th_line(artifacts: Vec<Artifact>) -> Vec<Artifact> {
+    return artifacts
+        .into_iter()
+        .map(|mut arti| {
+            if arti.unactivated_substats.len() == 0 || arti.rarity != 5 {
+                return arti;
+            }
+            arti.substats.push(arti.unactivated_substats.pop().unwrap());
+            return Artifact {
+                level: 4,
+                total_rolls: 4,
+                ..arti
+            };
+        })
+        .collect();
+}

--- a/src/player_data.rs
+++ b/src/player_data.rs
@@ -7,7 +7,7 @@ pub use auto_artifactarium::r#gen::protos::{AvatarInfo, Item};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
-use crate::good;
+use crate::good::{self, fake_uninitialized_4th_line};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ExportSettings {
@@ -15,6 +15,7 @@ pub struct ExportSettings {
     pub include_artifacts: bool,
     pub include_weapons: bool,
     pub include_materials: bool,
+    pub fake_initialize_4th_line: bool,
 
     pub min_character_level: u32,
     pub min_character_ascension: u32,
@@ -84,7 +85,12 @@ impl PlayerData {
         }
 
         if settings.include_artifacts {
-            good.artifacts = self.export_genshin_optimizer_artifacts(settings);
+            good.artifacts = if settings.fake_initialize_4th_line {
+                let artifacts = self.export_genshin_optimizer_artifacts(settings);
+                fake_uninitialized_4th_line(artifacts)
+            } else {
+                self.export_genshin_optimizer_artifacts(settings)
+            };
         }
 
         if settings.include_weapons {


### PR DESCRIPTION
Added GOOD export option to level up 3 liner 5* artis to trick GO into assessing 6.0+ artis correctly.
I also "fixed" the GOOD field renaming to a rename all to camelCase.