### PR TITLE
Filter Out Fake Item Packets

### DIFF
--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -144,10 +144,19 @@ impl Monitor {
                 }
             }
             if let Some(items) = matches_item_packet(&command) {
-                tracing::info!("Found item packet with {} items", items.len());
-                self.player_data.process_items(&items);
-                updated.items_updated = Some(Instant::now());
-                has_new_data = true;
+                if self.player_data.check_num_weapons(&items) >= 6
+                //6 guaranteed different free characters by AR18
+                {
+                    self.player_data.process_items(&items);
+                    tracing::info!("Found item packet with {} items", items.len());
+                    updated.items_updated = Some(Instant::now());
+                    has_new_data = true;
+                } else {
+                    tracing::info!(
+                        "Packet with {} items determined to be false positive. Discarded.",
+                        items.len()
+                    );
+                }
             } else if let Some(avatars) = matches_avatar_packet(&command) {
                 tracing::info!("Found avatar packet with {} avatars", avatars.len());
                 self.player_data.process_characters(&avatars);

--- a/src/player_data.rs
+++ b/src/player_data.rs
@@ -324,4 +324,19 @@ impl PlayerData {
             })
             .collect()
     }
+
+    pub fn check_num_weapons(&self, items: &[Item]) -> u32 {
+        items.iter().fold(0, |agg, item| {
+            if !item.has_equip() {
+                return agg;
+            }
+            let equip = item.equip();
+
+            if !equip.has_weapon() {
+                return agg;
+            }
+
+            return agg + 1;
+        })
+    }
 }


### PR DESCRIPTION
Sometimes a packet with more than 9 "items" passes the PacketWithItems parsing and overwrites the expected items data. This fix checks if there are at least 6 weapons in the data (an AR18 would be expected to have at least 6 unique characters).
Alternative fixes include:
Hardcoding the opcode (changes every patch)
Fetching the opcode like with Dim's data (changes every patch)
Only replace if there is more items (awful idea)