### PR TITLE
Prevent update check from panicking if no releases are found

### DIFF
--- a/src/update.rs
+++ b/src/update.rs
@@ -26,7 +26,11 @@ pub fn check_for_new_version() -> Result<Option<Release>> {
         .context("error fetching releases")?;
 
     // Assume the first release is the latest.
-    let release = releases[0].clone();
+    let release = releases
+        .first()
+        .ok_or(anyhow!("No releases found"))?
+        .clone();
+
     if release.version == self_update::cargo_crate_version!() {
         tracing::info!(
             "{} is current, continuing with app startup",


### PR DESCRIPTION
When doing the update check, there's no check to see if the `releases` array is empty, which causes a panic if some issue (like a GitHub outage) causes it to be empty. This PR solves this issue by returning an error instead.