### PR TITLE
monitor: stop capture task on closed channel and cap consecutive errors

### DIFF
--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -15,7 +15,7 @@ use flate2::read::GzDecoder;
 use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 
-use crate::capture::{BackendType, create_capture};
+use crate::capture::{BackendType, CaptureError, create_capture};
 use crate::player_data::PlayerData;
 use crate::{APP_ID, AppState, DataUpdated, Message, State};
 
@@ -194,18 +194,41 @@ async fn capture_task(
     packet_tx: mpsc::UnboundedSender<Vec<u8>>,
     backend: BackendType,
 ) -> Result<()> {
-    let mut capture = create_capture(backend)
-        .map_err(|e| anyhow!("Error creating packet capture using {:?}: {e}", backend))?;
+    let mut capture = match create_capture(backend) {
+        Ok(capture) => capture,
+        Err(e) => {
+            tracing::error!("Error creating packet capture using {backend:?}: {e}");
+            return Err(anyhow!(
+                "Error creating packet capture using {backend:?}: {e}"
+            ));
+        }
+    };
     tracing::info!("starting capture");
+    const MAX_CONSECUTIVE_ERRORS: u32 = 10;
+    let mut consecutive_errors: u32 = 0;
     loop {
         let packet = tokio::select!(
             packet = capture.next_packet() => packet,
             _ = cancel_token.cancelled() => break,
         );
         let packet = match packet {
-            Ok(packet) => packet,
+            Ok(packet) => {
+                consecutive_errors = 0;
+                packet
+            }
+            Err(CaptureError::CaptureClosed) => {
+                tracing::error!("Capture channel closed, stopping capture task");
+                break;
+            }
             Err(e) => {
+                consecutive_errors += 1;
                 tracing::error!("Error receiving packet: {e}");
+                if consecutive_errors >= MAX_CONSECUTIVE_ERRORS {
+                    tracing::error!(
+                        "Too many consecutive errors ({consecutive_errors}), stopping capture task"
+                    );
+                    break;
+                }
                 continue;
             }
         };


### PR DESCRIPTION
## Problem

When the capture backend's channel is closed (the pcap packet loop exited because of an error, or the backend was dropped), `next_packet()` returns `CaptureError::CaptureClosed` on **every** call. `capture_task` in `monitor.rs` treated it like a transient error — log and `continue` — so it spun forever, writing `Error receiving packet: ...` as fast as it could. On my machine one such session produced a **5.8 GB** log file before I noticed.

## Fix

- Break out of the loop on `CaptureError::CaptureClosed` (the channel will never yield again).
- Bail out after 10 consecutive errors of any other kind, resetting the counter on every successful packet.
- Log the error when `create_capture` fails, before returning it — that failure was otherwise easy to miss.

No behaviour change on the happy path.

## Testing

Built and ran on Windows 11 with the pcap backend (v0.2.0 + this patch): normal capture works; when the packet loop ends the task now stops after a single error line instead of flooding the log.

Possibly related to reports of "nothing happens" / huge logs in #86 / #95, though I can't confirm the root cause there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)