### PR TITLE
pcap: treat TimeoutExpired as non-fatal in the packet loop

### DIFF
--- a/src/capture/pcap_backend.rs
+++ b/src/capture/pcap_backend.rs
@@ -138,6 +138,11 @@ impl PcapBackend {
                         break;
                     }
                 }
+                Err(pcap::Error::TimeoutExpired) => {
+                    // No packets arrived within the read timeout window (common on Windows/Npcap
+                    // for idle devices); this is expected and not fatal, so keep polling.
+                    continue;
+                }
                 Err(err) => {
                     tracing::info!(
                         "Packet loop for device {} ending (has_captured: {}): capture error: {}",


### PR DESCRIPTION
## Problem

On Windows/Npcap, `Capture::next_packet()` returns `pcap::Error::TimeoutExpired` when no packet arrives within the read timeout. `packet_loop` handled it like any other error: forward it and `break`, killing that device's capture thread. Since c755e04 opens a capture on every connected device, an idle interface (e.g. a WAN Miniport) hitting the timeout is expected — and if the *real* NIC hits it during a quiet moment before login, the interface that carries the game traffic is silently gone.

## Fix

Match `Err(pcap::Error::TimeoutExpired)` explicitly and `continue`; every other error still ends the loop as before.

## Testing

Windows 11, Wi-Fi, Npcap: with v0.2.0 + this patch capture stays alive across idle periods and the session key is picked up at login. Verified `cargo check --features pcap` and `cargo fmt --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)