### PR TITLE
Default to the pcap backend on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ tokio = { version = "1.47.1", features = [
 winresource = "0.1.23"
 
 [features]
-default = []
+default = ["pcap"]
 pcap = ["dep:pcap"]
 static-libpcap = ["pcap"]
 

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -54,7 +54,7 @@ pub enum BackendType {
 }
 
 #[cfg(windows)]
-pub const DEFAULT_CAPTURE_BACKEND_TYPE: BackendType = BackendType::Pktmon;
+pub const DEFAULT_CAPTURE_BACKEND_TYPE: BackendType = BackendType::Pcap;
 #[cfg(not(windows))]
 pub const DEFAULT_CAPTURE_BACKEND_TYPE: BackendType = BackendType::Pcap;
 


### PR DESCRIPTION
## Motivation

On my setup (Windows 11, Wi-Fi) the pktmon backend regularly missed packets, so the session key at login was lost and decryption failed (`Couldn't bruteforce from deduced keys`) unless I retried several times. The pcap backend captured reliably every time. Reports like #86 / #95 ("doesn't capture anything after entering the door") may be the same thing, though I can't verify their setups.

## Change

- Enable the `pcap` cargo feature by default.
- Make `Pcap` the default `--capture-backend` on Windows as well; `--capture-backend pktmon` still selects the old backend.

## Trade-off (why this is a separate PR)

This makes Npcap a de-facto requirement for Windows users of the default binary — that's a product decision, so I've kept it apart from the two bug fixes (#142, #143) which stand on their own. Happy to close this one if you'd rather keep pktmon as the default and just document the flag.

Verified `cargo check` / `cargo fmt --check` on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)