### PR TITLE
Don't show Linux permissions instructions on macOS

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -145,12 +145,15 @@ fn show_packet_capture_permissions_missing_dialog() {
                 ui.vertical_centered(|ui| {
                     ui.label("How to grant packet capture permissions:");
                     ui.add_space(5.0);
-                    ui.label("1. Grant CAP_NET_RAW to Irminsul (after every update):");
-                    ui.label(format!(
-                        "{} && '{}'",
-                        setcap_command(&exe_path),
-                        exe_path
-                    ));
+                    #[cfg(target_os = "linux")]
+                    {
+                        ui.label("1. Grant CAP_NET_RAW to Irminsul (after every update):");
+                        ui.label(format!(
+                            "{} && '{}'",
+                            setcap_command(&exe_path),
+                            exe_path
+                        ));
+                    }
 
                     #[cfg(target_os = "macos")]
                     {


### PR DESCRIPTION
Oopsie:
<img width="520" height="258" alt="image" src="https://github.com/user-attachments/assets/de9ed7c8-d002-415c-a048-6f70cc66ac42" />

Need to gate LInux CAP_NET_RAW instructions to Linux.